### PR TITLE
An extra comma in method arguments was causing Python to fail

### DIFF
--- a/dask_cuda/local_cuda_cluster.py
+++ b/dask_cuda/local_cuda_cluster.py
@@ -35,7 +35,7 @@ class LocalCUDACluster(LocalCluster):
         threads_per_worker=1,
         processes=True,
         memory_limit=None,
-        **kwargs,
+        **kwargs
     ):
         if n_workers is None:
             n_workers = get_n_gpus()


### PR DESCRIPTION
To reproduce:

Install the LocalCUDACluster from source and `from dask_cuda import LocalCUDACluster`

